### PR TITLE
Require Java SE 17 as that is what Spring 6 requires. Do not use a ma…

### DIFF
--- a/galleon-feature-pack/src/main/resources/modules/system/layers/base/org/springframework/spring/main/module.xml
+++ b/galleon-feature-pack/src/main/resources/modules/system/layers/base/org/springframework/spring/main/module.xml
@@ -35,6 +35,9 @@
         <artifact name="${org.aspectj:aspectjweaver}"/>
     </resources>
     <dependencies>
+        <!-- for java.beans -->
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
         <module name="ch.qos.cal10n" optional="true"/>
         <module name="com.google.guava"/>
 <!--        <module name="jakarta.api"/>-->

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,10 @@
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.6.0</maven.min.version>
 
-        <!-- Require at least Java 11 to compile, but compile down to Java 8 -->
-        <jdk.min.version>11</jdk.min.version>
-        <javadoc.additional.params>--release=8</javadoc.additional.params>
+        <!-- Require at least Java 17 to compile -->
+        <jdk.min.version>17</jdk.min.version>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <!-- maven-surefire-plugin -->
         <surefire.system.args>-Xms512m -Xmx512m</surefire.system.args>
         <skip.java8.tests>false</skip.java8.tests>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -110,11 +110,11 @@
                         <log-time>${galleon.log.time}</log-time>
                         <offline>${galleon.offline}</offline>
                         <plugin-options>
-                            <jboss-maven-dist/>
+                            <!-- Disable maven distribution as we need the converted JAR's -->
+                            <!-- <jboss-maven-dist/> -->
                             <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                             <optional-packages>passive+</optional-packages>
                             <jboss-jakarta-transform-artifacts>true</jboss-jakarta-transform-artifacts>
-                            <jboss-maven-repo>https://repository.jboss.org/nexus/content/repositories/releases/</jboss-maven-repo>
                         </plugin-options>
                         <feature-packs>
                             <feature-pack>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -17,6 +17,7 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>resteasy-spring-test-bom</artifactId>
                 <version>${project.version}</version>
+                <type>pom</type>
                 <scope>import</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
…ven distribution of WildFly as we need the transformed JAR's. Add the java.desktop module dependency for java.beans.

@liweinan this should fix it. I will say too we should likely bump the version to either 2.1.0-SNAPSHOT or 3.0.0-SNAPSHOT since we're going to require Java SE 17 and we're doing a major bump of Spring.